### PR TITLE
support 4.1 as init signature changed for SEGScreenPayload

### DIFF
--- a/FullStoryMiddleware.xcodeproj/project.pbxproj
+++ b/FullStoryMiddleware.xcodeproj/project.pbxproj
@@ -62,9 +62,9 @@
 		04106E53251D2CFC007A2E69 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		04106E54251D2CFC007A2E69 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		04A74E82D1F81BD1D77CDD1A /* Pods-FullStoryMiddlewareExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddlewareExample.release.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddlewareExample/Pods-FullStoryMiddlewareExample.release.xcconfig"; sourceTree = "<group>"; };
-		04BE03BC2538965B0092EC6F /* FullStoryMiddleware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FullStoryMiddleware.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		04BE03BD2538965B0092EC6F /* FullStoryMiddlewareTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FullStoryMiddlewareTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		04BE03BE2538965B0092EC6F /* FullStoryMiddlewareExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FullStoryMiddlewareExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		04BE03BC2538965B0092EC6F /* FullStoryMiddleware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = FullStoryMiddleware.framework; path = "/Users/sabrina/Documents/ios/fullstory-segment-middleware-ios/build/Debug-iphoneos/FullStoryMiddleware.framework"; sourceTree = "<absolute>"; };
+		04BE03BD2538965B0092EC6F /* FullStoryMiddlewareTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = FullStoryMiddlewareTests.xctest; path = "/Users/sabrina/Documents/ios/fullstory-segment-middleware-ios/build/Debug-iphoneos/FullStoryMiddlewareTests.xctest"; sourceTree = "<absolute>"; };
+		04BE03BE2538965B0092EC6F /* FullStoryMiddlewareExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = FullStoryMiddlewareExample.app; path = "/Users/sabrina/Documents/ios/fullstory-segment-middleware-ios/build/Debug-iphoneos/FullStoryMiddlewareExample.app"; sourceTree = "<absolute>"; };
 		17D6CE0983DA4EEB9DF2AE1A /* Pods-FullStoryMiddlewareTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddlewareTests.release.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddlewareTests/Pods-FullStoryMiddlewareTests.release.xcconfig"; sourceTree = "<group>"; };
 		21235F9700236CE4B2F4EAAE /* Pods-FullStoryMiddlewareTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddlewareTests.debug.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddlewareTests/Pods-FullStoryMiddlewareTests.debug.xcconfig"; sourceTree = "<group>"; };
 		22DC07B9D1538ECCFB67C51E /* Pods-FullStoryMiddleware.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddleware.release.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddleware/Pods-FullStoryMiddleware.release.xcconfig"; sourceTree = "<group>"; };
@@ -121,9 +121,6 @@
 				04106E41251D2CFA007A2E69 /* FullStoryMiddlewareExample */,
 				E4302D4B1DEDD6B1ED6BA332 /* Pods */,
 				011EAF25B233502141487A39 /* Frameworks */,
-				04BE03BC2538965B0092EC6F /* FullStoryMiddleware.framework */,
-				04BE03BD2538965B0092EC6F /* FullStoryMiddlewareTests.xctest */,
-				04BE03BE2538965B0092EC6F /* FullStoryMiddlewareExample.app */,
 			);
 			sourceTree = "<group>";
 		};

--- a/FullStoryMiddleware/FullStoryMiddleware.m
+++ b/FullStoryMiddleware/FullStoryMiddleware.m
@@ -140,17 +140,17 @@
                 // init has a different signiture for Analytics version < 4
                 if ([uninitPayload respondsToSelector:@selector(initWithName:properties:context:integrations:)]) {
                     newPayload = [uninitPayload
-                               initWithName:screenPayload.name
-                               properties:newProps
-                               context:screenPayload.context
-                               integrations:screenPayload.integrations];
-                }else if ([uninitPayload respondsToSelector:@selector(initWithName:category:properties:context:integrations:)]) {
+                                  initWithName:screenPayload.name
+                                  properties:newProps
+                                  context:screenPayload.context
+                                  integrations:screenPayload.integrations];
+                } else if ([uninitPayload respondsToSelector:@selector(initWithName:category:properties:context:integrations:)]) {
                     newPayload = [uninitPayload
-                               initWithName:screenPayload.name
-                               category:screenPayload.category
-                               properties:newProps
-                               context:screenPayload.context
-                               integrations:screenPayload.integrations];
+                                  initWithName:screenPayload.name
+                                  category:screenPayload.category
+                                  properties:newProps
+                                  context:screenPayload.context
+                                  integrations:screenPayload.integrations];
                 } else {
                     // if not responding to either, return nil so we abort and pass the original paylaod back
                     newPayload = nil;

--- a/FullStoryMiddleware/FullStoryMiddleware.m
+++ b/FullStoryMiddleware/FullStoryMiddleware.m
@@ -151,6 +151,9 @@
                                properties:newProps
                                context:screenPayload.context
                                integrations:screenPayload.integrations];
+                } else {
+                    // if not responding to either, return nil so we abort and pass the original paylaod back
+                    newPayload = nil;
                 }
             }
             break;

--- a/FullStoryMiddleware/FullStoryMiddleware.m
+++ b/FullStoryMiddleware/FullStoryMiddleware.m
@@ -16,7 +16,7 @@
 // private SEGScreenPayload to provide the signitures to check for during respondsToSelector:@selector
 // this is due to a signiture change between Analytics 3 and 4.
 // We workaround it by checking if the init response to either of these below
-private @interface SEGScreenPayload()
+@interface SEGScreenPayload()
 - (instancetype)initWithName:(NSString *)name
                   properties:(NSDictionary *)properties
                      context:(NSDictionary *)context

--- a/FullStoryMiddlewareTests/FullStoryMiddlewareTest.m
+++ b/FullStoryMiddlewareTests/FullStoryMiddlewareTest.m
@@ -65,7 +65,7 @@
     OCMStub([segContextMock eventType]).andReturn(SEGEventTypeTrack);
        
     SEGPayload* result = [_fullStoryMiddleware getNewPayloadWithFSURL:segContextMock];
-    XCTAssertTrue([result isKindOfClass:[SEGTrackPayload class]]);
+    XCTAssertTrue(strcmp(object_getClassName(result), "SEGTrackPayload") == 0);
 }
 
 - (void)testFullStoryMiddleware_GetNewPayloadWithFSURL_TrackPayload_ReturnsTrackPayloadWithFSURL {
@@ -92,7 +92,7 @@
     OCMStub([segContextMock eventType]).andReturn(SEGEventTypeScreen);
    
     SEGPayload* result = [_fullStoryMiddleware getNewPayloadWithFSURL:segContextMock];
-    XCTAssertTrue([result isKindOfClass:[SEGScreenPayload class]]);
+    XCTAssertTrue(strcmp(object_getClassName(result), "SEGScreenPayload") == 0);
 }
 
 - (void)testFullStoryMiddleware_GetNewPayloadWithFSURL_ScreenPayload_ReturnsScreenPayloadWithFSURL {
@@ -120,8 +120,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -152,8 +152,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -186,8 +186,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -220,8 +220,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -256,8 +256,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -292,8 +292,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -329,8 +329,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -366,8 +366,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -405,8 +405,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -427,8 +427,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -461,8 +461,8 @@
     // assert the context is correct when next block is called
     void(^next)(SEGContext * _Nullable newContext) = ^(SEGContext * _Nullable newContext){
         XCTAssertEqual(newContext.eventType, context.eventType);
-        XCTAssertEqual(newContext.userId, context.userId);
-        XCTAssertEqual(newContext.anonymousId, context.anonymousId);
+        XCTAssertEqual(newContext.payload.userId, context.payload.userId);
+        XCTAssertEqual(newContext.payload.anonymousId, context.payload.anonymousId);
         XCTAssertEqual(newContext.debug, context.debug);
         XCTAssertEqualObjects(newContext._analytics, context._analytics);
         XCTAssertEqualObjects(newContext.error, context.error);
@@ -500,9 +500,10 @@
         }
         case SEGEventTypeScreen: {
             SEGScreenPayload *screenPayload = [[SEGScreenPayload alloc] initWithName:@"testScreen"
-                                                                  properties:@{@"prop":@"testProp"}
-                                                                     context:emptyDict
-                                                                integrations:emptyDict];
+                                                                            category:@"testCategory"
+                                                                          properties:@{@"prop":@"testProp"}
+                                                                             context:emptyDict
+                                                                        integrations:emptyDict];
 
             return [[[SEGContext alloc] initWithAnalytics:sharedAnalytics]
                     modify:^(id<SEGMutableContext> _Nonnull ctx) {
@@ -572,6 +573,7 @@
         }
         case SEGEventTypeScreen: {
             return [[SEGScreenPayload alloc] initWithName:@"testScreen"
+                                                 category:@"testCategory"
                                                properties:props
                                                   context:emptyDict
                                              integrations:emptyDict];

--- a/Podfile
+++ b/Podfile
@@ -1,12 +1,11 @@
-platform :ios, '9.0'
+platform :ios, '11.0'
 
 def common_pods
-  pod 'FullStory', :http => 'https://ios-releases.fullstory.com/fullstory-1.7.0.tar.gz'
-  pod 'Analytics', '~> 3.0'
+  pod 'FullStory', :http => 'https://ios-releases.fullstory.com/fullstory-1.10.0.tar.gz'
+  pod 'Analytics', '~> 4.1.0'
 end
 
 target 'FullStoryMiddleware' do
-  common_pods
 end
 
 target 'FullStoryMiddlewareTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Analytics (3.9.0)
-  - FullStory (1.7.0)
+  - Analytics (4.1.2)
+  - FullStory (1.10.0)
   - FullStorySegmentMiddleware (0.1.0):
     - Analytics
     - FullStory
   - OCMock (3.7.1)
 
 DEPENDENCIES:
-  - Analytics (~> 3.0)
-  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.7.0.tar.gz\"}`)"
+  - Analytics (~> 4.1.0)
+  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.10.0.tar.gz\"}`)"
   - FullStorySegmentMiddleware (from `.`)
   - OCMock (~> 3.6)
 
@@ -19,20 +19,20 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.7.0.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.10.0.tar.gz
   FullStorySegmentMiddleware:
     :path: "."
 
 CHECKOUT OPTIONS:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.7.0.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.10.0.tar.gz
 
 SPEC CHECKSUMS:
-  Analytics: 67cce2129e4b0df5b532bf0c043043f292b32f5f
-  FullStory: 3f0aeecb6edb80c4dcd10cb88c805d103f6e0ad5
+  Analytics: 177da2c597aba83a6882b706ca6e0a071fd7cd26
+  FullStory: c57124b88b7139f5c737195d270dee3c756f6b0c
   FullStorySegmentMiddleware: ec0fe978d4d2e3fc52bc68d5103764ec335cf0f5
   OCMock: 75fbeaa46a9b11f8c182bbb1d1f7e9a35ccc9955
 
-PODFILE CHECKSUM: c0c20d3840783f75c61e3059b5d3a6c81e5c89c5
+PODFILE CHECKSUM: 4c3fd369f7b528eb473c97a3fbdc231be5366480
 
 COCOAPODS: 1.9.1


### PR DESCRIPTION
Since SEGAnalytics 4.1 (that supports iOS14) signature for SEGScreenPayload init changed from 
```
[[SEGScreenPayload alloc]
                                           initWithName:screenPayload.name
                                           properties:newProps
                                           context:screenPayload.context
                                           integrations:screenPayload.integrations];
```
to 
```
[[SEGScreenPayload alloc]
                                           initWithName:screenPayload.name
                                           properties:newProps
                                           category: screenPayload.category
                                           context:screenPayload.context
                                           integrations:screenPayload.integrations];
```
with no backwards compatibility. So had to workaround it by setting the the "name, category, and properties" after initializing the payload - not ideal, but gets us unstuck for now