### PR TITLE
Sabrina/segment import changes

### DIFF
--- a/FullStoryMiddleware/FullStoryMiddleware.h
+++ b/FullStoryMiddleware/FullStoryMiddleware.h
@@ -10,7 +10,12 @@
 #define FullStoryMiddleware_h
 
 #import <Foundation/Foundation.h>
-#import <Analytics/SEGMiddleware.h>
+#import <FullStory/FullStory.h>
+#if defined(__has_include) && __has_include(<Analytics/SEGAnalytics.h>)
+#import <Analytics/SEGAnalytics.h>
+#else
+@import Segment;
+#endif
 
 //! Project version number for FullStoryMiddleware.
 FOUNDATION_EXPORT double FullStoryMiddlewareVersionNumber;

--- a/FullStoryMiddleware/FullStoryMiddleware.h
+++ b/FullStoryMiddleware/FullStoryMiddleware.h
@@ -17,6 +17,10 @@
 @import Segment;
 #endif
 
+#if defined(__has_include) && __has_include(<Analytics/SEGMiddleware.h>)
+#import <Analytics/SEGMiddleware.h>
+#endif
+
 //! Project version number for FullStoryMiddleware.
 FOUNDATION_EXPORT double FullStoryMiddlewareVersionNumber;
 

--- a/FullStoryMiddleware/FullStoryMiddleware.m
+++ b/FullStoryMiddleware/FullStoryMiddleware.m
@@ -7,8 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <Analytics/SEGMiddleware.h>
-#import <FullStory/FullStory.h>
 #import "FullStoryMiddleware.h"
 #import "FSSuffixedProperties.h"
 

--- a/FullStoryMiddlewareExample/AppDelegate.m
+++ b/FullStoryMiddlewareExample/AppDelegate.m
@@ -7,7 +7,6 @@
 //
 
 #import "AppDelegate.h"
-#import <Analytics/SEGAnalytics.h>
 #import <FullStoryMiddleware/FullStoryMiddleware.h>
 
 @interface AppDelegate ()

--- a/FullStoryMiddlewareExample/ViewController.h
+++ b/FullStoryMiddlewareExample/ViewController.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <Analytics/SEGAnalytics.h>
 
 @interface ViewController : UIViewController
 

--- a/FullStoryMiddlewareExample/ViewController.m
+++ b/FullStoryMiddlewareExample/ViewController.m
@@ -7,7 +7,6 @@
 //
 
 #import "ViewController.h"
-#import <Analytics/SEGAnalytics.h>
 
 @interface ViewController ()
 

--- a/FullStoryMiddlewareTests/FullStoryMiddlewareTest.m
+++ b/FullStoryMiddlewareTests/FullStoryMiddlewareTest.m
@@ -8,7 +8,6 @@
 
 #import <XCTest/XCTest.h>
 #import <Foundation/Foundation.h>
-#import <Analytics/SEGAnalytics.h>
 #import <FullStory/FullStory.h>
 #import <OCMock/OCMock.h>
 #import "FullStoryMiddleware.h"

--- a/FullStorySegmentMiddleware.podspec
+++ b/FullStorySegmentMiddleware.podspec
@@ -126,6 +126,5 @@ Pod::Spec.new do |spec|
 
   # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
   spec.dependency 'FullStory'
-  spec.dependency 'Analytics'
-
+  spec.dependency 'Analytics', '~> 4.1'
 end

--- a/FullStorySegmentMiddleware.podspec
+++ b/FullStorySegmentMiddleware.podspec
@@ -126,5 +126,5 @@ Pod::Spec.new do |spec|
 
   # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
   spec.dependency 'FullStory'
-  spec.dependency 'Analytics', '~> 4.1'
+  spec.dependency 'Analytics'
 end

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '11.0'
 
 def common_pods
-  pod 'FullStory', :http => 'https://ios-releases.fullstory.com/fullstory-1.17.1.tar.gz'
+  pod 'FullStory', :http => 'https://ios-releases.fullstory.com/fullstory-1.18.0.tar.gz'
   pod 'Analytics', '~> 4.1'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,8 @@
 platform :ios, '11.0'
 
 def common_pods
-  pod 'FullStory', :http => 'https://ios-releases.fullstory.com/fullstory-1.10.0.tar.gz'
-  pod 'Analytics', '~> 4.1.0'
+  pod 'FullStory', :http => 'https://ios-releases.fullstory.com/fullstory-1.17.1.tar.gz'
+  pod 'Analytics', '~> 4.1'
 end
 
 target 'FullStoryMiddleware' do
@@ -11,7 +11,7 @@ end
 
 target 'FullStoryMiddlewareTests' do
   common_pods
-  pod 'OCMock', '~>3.6'
+  pod 'OCMock', '~> 3.6'
 end
 
 target 'FullStoryMiddlewareExample' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - Analytics (4.1.5)
-  - FullStory (1.17.1)
+  - FullStory (1.18.0)
   - FullStorySegmentMiddleware (0.1.0):
-    - Analytics (~> 4.1)
+    - Analytics
     - FullStory
   - OCMock (3.8.1)
 
 DEPENDENCIES:
   - Analytics (~> 4.1)
-  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.17.1.tar.gz\"}`)"
+  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.18.0.tar.gz\"}`)"
   - FullStorySegmentMiddleware (from `.`)
   - OCMock (~> 3.6)
 
@@ -19,20 +19,20 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.17.1.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.18.0.tar.gz
   FullStorySegmentMiddleware:
     :path: "."
 
 CHECKOUT OPTIONS:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.17.1.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.18.0.tar.gz
 
 SPEC CHECKSUMS:
   Analytics: 084a3edda6517e308007c1a7810b8f1e8f2925aa
-  FullStory: eadfce6bbdd46f4ea339372386929f9098543ce9
-  FullStorySegmentMiddleware: 8d4c9786eaa89eeabf2aba58a8769993e5c692bc
+  FullStory: e8840082c25f8f591121916d51a396e225b18caa
+  FullStorySegmentMiddleware: ec0fe978d4d2e3fc52bc68d5103764ec335cf0f5
   OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
 
-PODFILE CHECKSUM: b462e02019e445e85a07dcea410355c46abb1188
+PODFILE CHECKSUM: 024d1a1c3fbf7a5f3c8e2ee3b0d37dbdde7a0588
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Analytics (4.1.2)
-  - FullStory (1.10.0)
+  - Analytics (4.1.5)
+  - FullStory (1.17.1)
   - FullStorySegmentMiddleware (0.1.0):
-    - Analytics
+    - Analytics (~> 4.1)
     - FullStory
-  - OCMock (3.7.1)
+  - OCMock (3.8.1)
 
 DEPENDENCIES:
-  - Analytics (~> 4.1.0)
-  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.10.0.tar.gz\"}`)"
+  - Analytics (~> 4.1)
+  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.17.1.tar.gz\"}`)"
   - FullStorySegmentMiddleware (from `.`)
   - OCMock (~> 3.6)
 
@@ -19,20 +19,20 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.10.0.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.17.1.tar.gz
   FullStorySegmentMiddleware:
     :path: "."
 
 CHECKOUT OPTIONS:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.10.0.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.17.1.tar.gz
 
 SPEC CHECKSUMS:
-  Analytics: 177da2c597aba83a6882b706ca6e0a071fd7cd26
-  FullStory: c57124b88b7139f5c737195d270dee3c756f6b0c
-  FullStorySegmentMiddleware: ec0fe978d4d2e3fc52bc68d5103764ec335cf0f5
-  OCMock: 75fbeaa46a9b11f8c182bbb1d1f7e9a35ccc9955
+  Analytics: 084a3edda6517e308007c1a7810b8f1e8f2925aa
+  FullStory: eadfce6bbdd46f4ea339372386929f9098543ce9
+  FullStorySegmentMiddleware: 8d4c9786eaa89eeabf2aba58a8769993e5c692bc
+  OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
 
-PODFILE CHECKSUM: 761e6384a914af500e4a2f140814025212190438
+PODFILE CHECKSUM: b462e02019e445e85a07dcea410355c46abb1188
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.1


### PR DESCRIPTION
Breaking change:
Since Segment 4.1, the cocoapods module name is changed from Analytics -> Segment:
https://github.com/segmentio/analytics-ios/blob/master/CHANGELOG.md#version-410-19-october-2020

So to support 4.1+ we need to check if we should import from `<Analytics/SEGAnalytics.h>`, or `@import Segment;` (client is using objC vs swift)

Also did some clean up for some redundant imports 