### PR TITLE
Using FullStory 1.19.1

### DIFF
--- a/FullStoryMiddleware.xcodeproj/project.pbxproj
+++ b/FullStoryMiddleware.xcodeproj/project.pbxproj
@@ -62,14 +62,14 @@
 		04106E53251D2CFC007A2E69 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		04106E54251D2CFC007A2E69 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		04A74E82D1F81BD1D77CDD1A /* Pods-FullStoryMiddlewareExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddlewareExample.release.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddlewareExample/Pods-FullStoryMiddlewareExample.release.xcconfig"; sourceTree = "<group>"; };
-		04BE03BC2538965B0092EC6F /* FullStoryMiddleware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = FullStoryMiddleware.framework; path = "/Users/sabrina/Documents/ios/fullstory-segment-middleware-ios/build/Debug-iphoneos/FullStoryMiddleware.framework"; sourceTree = "<absolute>"; };
-		04BE03BD2538965B0092EC6F /* FullStoryMiddlewareTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = FullStoryMiddlewareTests.xctest; path = "/Users/sabrina/Documents/ios/fullstory-segment-middleware-ios/build/Debug-iphoneos/FullStoryMiddlewareTests.xctest"; sourceTree = "<absolute>"; };
-		04BE03BE2538965B0092EC6F /* FullStoryMiddlewareExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = FullStoryMiddlewareExample.app; path = "/Users/sabrina/Documents/ios/fullstory-segment-middleware-ios/build/Debug-iphoneos/FullStoryMiddlewareExample.app"; sourceTree = "<absolute>"; };
 		17D6CE0983DA4EEB9DF2AE1A /* Pods-FullStoryMiddlewareTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddlewareTests.release.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddlewareTests/Pods-FullStoryMiddlewareTests.release.xcconfig"; sourceTree = "<group>"; };
 		21235F9700236CE4B2F4EAAE /* Pods-FullStoryMiddlewareTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddlewareTests.debug.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddlewareTests/Pods-FullStoryMiddlewareTests.debug.xcconfig"; sourceTree = "<group>"; };
 		22DC07B9D1538ECCFB67C51E /* Pods-FullStoryMiddleware.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddleware.release.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddleware/Pods-FullStoryMiddleware.release.xcconfig"; sourceTree = "<group>"; };
 		59986B49906FF607E3B20F54 /* libPods-FullStoryMiddlewareTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FullStoryMiddlewareTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6386EDB2E2C02816EE0188BE /* libPods-FullStoryMiddlewareExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FullStoryMiddlewareExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6944B71B272C471100F2A831 /* FullStoryMiddleware.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FullStoryMiddleware.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6944B71C272C471100F2A831 /* FullStoryMiddlewareTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FullStoryMiddlewareTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		6944B71D272C471100F2A831 /* FullStoryMiddlewareExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FullStoryMiddlewareExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A2626ED4BB3DFEB2621319AA /* Pods-FullStoryMiddleware.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddleware.debug.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddleware/Pods-FullStoryMiddleware.debug.xcconfig"; sourceTree = "<group>"; };
 		A6AD7FE6FAFA682A46013891 /* libPods-FullStoryMiddleware.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-FullStoryMiddleware.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4AE545A30E82F8A01AEE81A /* Pods-FullStoryMiddlewareExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FullStoryMiddlewareExample.debug.xcconfig"; path = "Target Support Files/Pods-FullStoryMiddlewareExample/Pods-FullStoryMiddlewareExample.debug.xcconfig"; sourceTree = "<group>"; };
@@ -121,6 +121,9 @@
 				04106E41251D2CFA007A2E69 /* FullStoryMiddlewareExample */,
 				E4302D4B1DEDD6B1ED6BA332 /* Pods */,
 				011EAF25B233502141487A39 /* Frameworks */,
+				6944B71B272C471100F2A831 /* FullStoryMiddleware.framework */,
+				6944B71C272C471100F2A831 /* FullStoryMiddlewareTests.xctest */,
+				6944B71D272C471100F2A831 /* FullStoryMiddlewareExample.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -212,7 +215,7 @@
 			);
 			name = FullStoryMiddleware;
 			productName = FullStoryMiddleware;
-			productReference = 04BE03BC2538965B0092EC6F /* FullStoryMiddleware.framework */;
+			productReference = 6944B71B272C471100F2A831 /* FullStoryMiddleware.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		04106DA3251D27BE007A2E69 /* FullStoryMiddlewareTests */ = {
@@ -232,7 +235,7 @@
 			);
 			name = FullStoryMiddlewareTests;
 			productName = FullStoryMiddlewareTests;
-			productReference = 04BE03BD2538965B0092EC6F /* FullStoryMiddlewareTests.xctest */;
+			productReference = 6944B71C272C471100F2A831 /* FullStoryMiddlewareTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		04106E3F251D2CFA007A2E69 /* FullStoryMiddlewareExample */ = {
@@ -251,7 +254,7 @@
 			);
 			name = FullStoryMiddlewareExample;
 			productName = FullStoryMiddlewareExample;
-			productReference = 04BE03BE2538965B0092EC6F /* FullStoryMiddlewareExample.app */;
+			productReference = 6944B71D272C471100F2A831 /* FullStoryMiddlewareExample.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -540,7 +543,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -598,7 +601,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -622,12 +625,12 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = FullStoryMiddleware/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fullstorydev.FullStoryMiddleware;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -649,12 +652,12 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = FullStoryMiddleware/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.fullstorydev.FullStoryMiddleware;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -708,7 +711,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = KZF5HG57S9;
 				INFOPLIST_FILE = FullStoryMiddlewareExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -728,7 +730,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = KZF5HG57S9;
 				INFOPLIST_FILE = FullStoryMiddlewareExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/FullStoryMiddleware/Info.plist
+++ b/FullStoryMiddleware/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/FullStorySegmentMiddleware.podspec
+++ b/FullStorySegmentMiddleware.podspec
@@ -1,130 +1,16 @@
-#
-#  Be sure to run `pod spec lint FullStoryMiddleware.podspec' to ensure this is a
-#  valid spec and to remove all comments including this before submitting the spec.
-#
-#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
-#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
-#
-
 Pod::Spec.new do |spec|
-
-  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  These will help people to find your library, and whilst it
-  #  can feel like a chore to fill in it's definitely to your advantage. The
-  #  summary should be tweet-length, and the description more in depth.
-  #
-
-  spec.name         = "FullStorySegmentMiddleware"
-  spec.version      = "0.1.0"
-  spec.summary      = "Demonstrates the full potential of joining forces between Segment and FullStory."
-  # This description is used to generate tags and improve search results.
-  #   * Think: What does it do? Why did you write it? What is the focus?
-  #   * Try to keep it short, snappy and to the point.
-  #   * Write the description between the DESC delimiters below.
-  #   * Finally, don't worry about the indent, CocoaPods strips it!
-  spec.description  = <<-DESC
-  This demonstrates the full potential of joining forces between Segment and FullStory.
-  TODO: detailed description needed here
-                   DESC
-
-  spec.homepage     = "https://github.com/fullstorydev/fullstory-segment-middleware-ios"
-
-
-  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Licensing your code is important. See https://choosealicense.com for more info.
-  #  CocoaPods will detect a license file if there is a named LICENSE*
-  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
-  #
-
-  spec.license      = { :type => 'MIT', :file => 'LICENSE' }
-
-
-  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the authors of the library, with email addresses. Email addresses
-  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
-  #  accepts just a name if you'd rather not provide an email address.
-  #
-  #  Specify a social_media_url where others can refer to, for example a twitter
-  #  profile URL.
-  #
-
-  spec.author             = { 'FullStory' => 'https://www.fullstory.com' }
-
-
-  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If this Pod runs only on iOS or OS X, then specify the platform and
-  #  the deployment target. You can optionally include the target after the platform.
-  #
-
-  spec.platform     = :ios, "8.0"
-
-  #  When using multiple platforms
-  # spec.ios.deployment_target = "5.0"
-  # spec.osx.deployment_target = "10.7"
-  # spec.watchos.deployment_target = "2.0"
-  # spec.tvos.deployment_target = "9.0"
-
-
-  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the location from where the source should be retrieved.
-  #  Supports git, hg, bzr, svn and HTTP.
-  #
-
-  spec.source       = { :git => 'https://github.com/fullstorydev/fullstory-segment-middleware-ios.git', :tag => spec.version.to_s }
-
-
-  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  CocoaPods is smart about how it includes source code. For source files
-  #  giving a folder will include any swift, h, m, mm, c & cpp files.
-  #  For header files it will include any header in the folder.
-  #  Not including the public_header_files will make all headers public.
-  #
-
-  spec.source_files  = "FullStoryMiddleware"
-
-
-  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  A list of resources included with the Pod. These are copied into the
-  #  target bundle with a build phase script. Anything else will be cleaned.
-  #  You can preserve files from being cleaned, please don't preserve
-  #  non-essential files like tests, examples and documentation.
-  #
-
-  # spec.resource  = "icon.png"
-  # spec.resources = "Resources/*.png"
-
-  # spec.preserve_paths = "FilesToSave", "MoreFilesToSave"
-
-
-  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Link your library with frameworks, or libraries. Libraries do not include
-  #  the lib prefix of their name.
-  #
-
-  # spec.framework  = "SomeFramework"
-  # spec.frameworks = "SomeFramework", "AnotherFramework"
-
-  # spec.library   = "iconv"
-  # spec.libraries = "iconv", "xml2"
-
-
-  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If your library depends on compiler flags you can set them in the xcconfig hash
-  #  where they will only apply to your library. If you depend on other Podspecs
-  #  you can include multiple dependencies to ensure it works.
-
-  # spec.requires_arc = true
-
-  # spec.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  spec.name         = 'FullStorySegmentMiddleware'
+  spec.version      = '1.2.1'
+  spec.summary      = 'Demonstrates the full potential of joining forces between Segment and FullStory.'
+  spec.homepage     = 'https://github.com/fullstorydev/fullstory-segment-middleware-ios'
+  spec.license      = { type: 'MIT', file: 'LICENSE' }
+  spec.author       = { 'FullStory' => 'https://www.fullstory.com' }
+  spec.source       = { git: 'https://github.com/fullstorydev/fullstory-segment-middleware-ios.git', tag: spec.version.to_s }
+  
+  spec.ios.deployment_target = '12.0'
+  
+  spec.source_files = 'FullStoryMiddleware'
+  
   spec.dependency 'FullStory'
   spec.dependency 'Analytics'
 end

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,7 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 def common_pods
-  pod 'FullStory', :http => 'https://ios-releases.fullstory.com/fullstory-1.18.0.tar.gz'
+  pod 'FullStory', http: 'https://ios-releases.fullstory.com/fullstory-1.19.1.tar.gz'
   pod 'Analytics', '~> 4.1'
 end
 
@@ -11,10 +11,10 @@ end
 
 target 'FullStoryMiddlewareTests' do
   common_pods
-  pod 'OCMock', '~> 3.6'
+  pod 'OCMock', '~> 3.8'
 end
 
 target 'FullStoryMiddlewareExample' do
   common_pods
-  pod 'FullStorySegmentMiddleware', :path => '.'
+  pod 'FullStorySegmentMiddleware', path: '.'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Analytics (4.1.5)
-  - FullStory (1.18.0)
-  - FullStorySegmentMiddleware (0.1.0):
+  - Analytics (4.1.6)
+  - FullStory (1.19.1)
+  - FullStorySegmentMiddleware (1.2.1):
     - Analytics
     - FullStory
   - OCMock (3.8.1)
 
 DEPENDENCIES:
   - Analytics (~> 4.1)
-  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.18.0.tar.gz\"}`)"
+  - "FullStory (from `{:http=>\"https://ios-releases.fullstory.com/fullstory-1.19.1.tar.gz\"}`)"
   - FullStorySegmentMiddleware (from `.`)
-  - OCMock (~> 3.6)
+  - OCMock (~> 3.8)
 
 SPEC REPOS:
   trunk:
@@ -19,20 +19,20 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.18.0.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.19.1.tar.gz
   FullStorySegmentMiddleware:
     :path: "."
 
 CHECKOUT OPTIONS:
   FullStory:
-    :http: https://ios-releases.fullstory.com/fullstory-1.18.0.tar.gz
+    :http: https://ios-releases.fullstory.com/fullstory-1.19.1.tar.gz
 
 SPEC CHECKSUMS:
-  Analytics: 084a3edda6517e308007c1a7810b8f1e8f2925aa
-  FullStory: e8840082c25f8f591121916d51a396e225b18caa
-  FullStorySegmentMiddleware: ec0fe978d4d2e3fc52bc68d5103764ec335cf0f5
+  Analytics: eefe524436f904b8bb3f8c8c3425280e43b34efc
+  FullStory: 870920ff9930d7ec298cb6688a4e8d5beab228ca
+  FullStorySegmentMiddleware: 7682f00cf3e5dfc60876bfefd73b566afea7ee5d
   OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
 
-PODFILE CHECKSUM: 024d1a1c3fbf7a5f3c8e2ee3b0d37dbdde7a0588
+PODFILE CHECKSUM: 2f4cc8235b5b4b9c51d3968529a49a5db088215c
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ With FullStory for Mobile Apps, you can retrieve a link to the session replay an
     - Use CocoaPods to add to project:
 
       ```ruby
-      pod 'FullStorySegmentMiddleware', :git => 'https://github.com/fullstorydev/fullstory-segment-middleware-ios.git',:tag => '1.2'
+      pod 'FullStorySegmentMiddleware', :git => 'https://github.com/fullstorydev/fullstory-segment-middleware-ios.git',:tag => '1.2.1'
       ```
 
     - Alternatively, download the files manually:


### PR DESCRIPTION
This PR:
- Updates FullStory to 1.19.1
- Sets minimum iOS version to 12.0 project-wide (to match both FS and Segment requirements)
- Set framework proper version
- Updated OCMock lib
- Simplified Podspec and Podfile contents